### PR TITLE
fix: Correct SQL script for UUID primary key in config table

### DIFF
--- a/SETUP_AUTH_SUPABASE.md
+++ b/SETUP_AUTH_SUPABASE.md
@@ -1,0 +1,87 @@
+# Configuración de Autenticación con Supabase
+
+Este documento explica cómo configurar la autenticación usando la tabla de configuración de Supabase en lugar de solo variables de entorno.
+
+## Problema Identificado
+
+La aplicación usa Supabase para gestionar la configuración (tabla `config`), pero el sistema de autenticación estaba intentando usar solo variables de entorno. Esto causa el error:
+
+```
+⚠️ APP_PASSWORD no configurada en las variables de entorno
+```
+
+## Solución
+
+### Paso 1: Configurar la Base de Datos
+
+1. Ve al SQL Editor de Supabase: https://stik.axcsol.com/project/default/editor/53984
+2. Ejecuta el script `supabase_auth_setup.sql`:
+
+```sql
+-- Agregar el campo app_password a la tabla config
+ALTER TABLE config ADD COLUMN IF NOT EXISTS app_password TEXT;
+
+-- Insertar la contraseña (cambia 'tu-contraseña-segura' por la que desees)
+INSERT INTO config (id, app_password) 
+VALUES (1, 'tu-contraseña-segura')
+ON CONFLICT (id) 
+DO UPDATE SET app_password = EXCLUDED.app_password;
+
+-- Verificar
+SELECT id, app_password FROM config WHERE id = 1;
+```
+
+### Paso 2: Actualizar el Código JavaScript
+
+Reemplazar las funciones de autenticación en `app.js` con el código de `auth_supabase_integration.js`.
+
+Los cambios principales son:
+
+1. **validatePassword()** ahora llama a `getPasswordFromConfig()`
+2. **getPasswordFromConfig()** busca la contraseña en:
+   - Primero: `state.config.appPassword` (configuración cargada)
+   - Segundo: Consulta directa a Supabase `config` table
+   - Tercero: Fallback a `window.ENV.APP_PASSWORD`
+
+3. **cargarConfiguracion()** debe incluir `app_password` en la consulta SELECT
+
+### Paso 3: Modificaciones Específicas
+
+#### En la función cargarConfiguracion()
+Asegúrate de que la consulta incluya el campo `app_password`:
+
+```javascript
+// Buscar esta línea:
+const response = await fetch(getSupabaseUrl('config?select=*'), {
+
+// Y asegurarse de que incluya app_password en los campos seleccionados
+```
+
+#### En el objeto state
+Agregar el campo `appPassword` al estado de configuración cuando se carga desde Supabase.
+
+## Ventajas de este Enfoque
+
+1. **Consistencia**: Usa el mismo sistema de configuración que el resto de la aplicación
+2. **Flexibilidad**: Permite cambiar la contraseña desde el panel de admin
+3. **Fallback**: Si falla Supabase, usa la variable de entorno como respaldo
+4. **Seguridad**: La contraseña está en la base de datos, no en el código
+
+## Cambiar la Contraseña
+
+Para cambiar la contraseña más tarde:
+
+```sql
+UPDATE config SET app_password = 'nueva-contraseña' WHERE id = 1;
+```
+
+O implementar un campo en el panel de administración para cambiarla desde la interfaz.
+
+## Verificación
+
+Después de implementar:
+
+1. La aplicación debe mostrar el modal de autenticación
+2. Debe aceptar la contraseña configurada en Supabase
+3. Los logs deben mostrar que la configuración se carga correctamente
+4. Ya no debe aparecer el error de "APP_PASSWORD no configurada"

--- a/SETUP_AUTH_SUPABASE_FIXED.md
+++ b/SETUP_AUTH_SUPABASE_FIXED.md
@@ -1,0 +1,95 @@
+# Configuración de Autenticación con Supabase (Corregido para UUID)
+
+Este documento explica cómo configurar la autenticación usando la tabla de configuración de Supabase con claves UUID.
+
+## Problema Identificado
+
+La tabla `config` usa UUID como clave primaria, no enteros. El script SQL anterior fallaba con:
+```
+ERROR: column "id" is of type uuid but expression is of type integer
+```
+
+## Solución Corregida
+
+### Paso 1: Configurar la Base de Datos
+
+1. Ve al SQL Editor de Supabase: https://stik.axcsol.com/project/default/editor/53984
+2. Ejecuta el script paso a paso:
+
+```sql
+-- 1. Agregar el campo app_password
+ALTER TABLE config ADD COLUMN IF NOT EXISTS app_password TEXT;
+
+-- 2. Verificar registros existentes
+SELECT * FROM config LIMIT 5;
+```
+
+3. **Si hay registros existentes** (lo más probable), ejecuta:
+```sql
+UPDATE config SET app_password = 'tu-contraseña-segura' 
+WHERE id = (SELECT id FROM config LIMIT 1);
+```
+
+4. **Si NO hay registros**, ejecuta:
+```sql
+INSERT INTO config (id, app_password) 
+VALUES (gen_random_uuid(), 'tu-contraseña-segura');
+```
+
+5. **Verificar el resultado**:
+```sql
+SELECT id, app_password FROM config;
+```
+
+### Paso 2: Actualizar el Código JavaScript
+
+Usa el código de `auth_supabase_integration_fixed.js` que:
+
+1. **getPasswordFromConfig()** ahora usa `limit=1` en lugar de filtrar por `id=1`
+2. **Maneja UUIDs correctamente** en las consultas
+3. **Incluye fallback** a variables de entorno
+
+### Paso 3: Modificar cargarConfiguracion()
+
+En `app.js`, busca la función `cargarConfiguracion()` y asegúrate de que cuando carga la configuración desde Supabase, incluya:
+
+```javascript
+if (configData && configData.length > 0) {
+    const config = configData[0];
+    state.config = {
+        ...state.config,
+        appTitle: config.app_title || state.config.appTitle,
+        adminCode: config.admin_code || state.config.adminCode,
+        securityCode: config.security_code || state.config.securityCode,
+        appPassword: config.app_password || null  // <-- AGREGAR ESTA LÍNEA
+    };
+}
+```
+
+## Verificación
+
+Después de implementar:
+
+1. La consulta SQL debe mostrar el registro con `app_password` configurado
+2. La aplicación debe cargar la contraseña desde Supabase
+3. El modal de autenticación debe aceptar la contraseña configurada
+4. Ya no debe aparecer el error de "APP_PASSWORD no configurada"
+
+## Cambiar la Contraseña
+
+Para cambiar la contraseña más tarde:
+
+```sql
+UPDATE config SET app_password = 'nueva-contraseña' 
+WHERE id = (SELECT id FROM config LIMIT 1);
+```
+
+## Estructura de la Tabla Config
+
+La tabla `config` debería tener algo así:
+
+| id (UUID) | app_title | admin_code | security_code | app_password |
+|-----------|-----------|------------|---------------|-------------|
+| uuid-123... | Sistema de Tickets | admin123 | 12 | tu-contraseña-segura |
+
+Esto es consistente con cómo la aplicación maneja toda su configuración.

--- a/auth_supabase_integration.js
+++ b/auth_supabase_integration.js
@@ -1,0 +1,139 @@
+// Modificaciones necesarias para app.js
+// Estas funciones deben reemplazar las funciones de autenticación existentes
+
+// === FUNCIONES DE AUTENTICACIÓN CON SUPABASE ===
+
+// Configurar autenticación
+function setupAuthentication() {
+    const authModal = document.getElementById('authModal');
+    const authSubmit = document.getElementById('authSubmit');
+    const appPassword = document.getElementById('appPassword');
+    const authError = document.getElementById('authError');
+    
+    // Verificar si ya está autenticado (sesión guardada)
+    const sessionAuth = sessionStorage.getItem('app_authenticated');
+    if (sessionAuth === 'true') {
+        state.authenticated = true;
+        authModal.classList.remove('active');
+        initializeApp();
+        return;
+    }
+    
+    // Manejar submit con Enter
+    appPassword.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            validatePassword();
+        }
+    });
+    
+    // Manejar click en botón
+    authSubmit.addEventListener('click', validatePassword);
+}
+
+// Validar contraseña usando configuración de Supabase
+async function validatePassword() {
+    const appPassword = document.getElementById('appPassword');
+    const authError = document.getElementById('authError');
+    const authModal = document.getElementById('authModal');
+    
+    const enteredPassword = appPassword.value;
+    
+    try {
+        // Obtener la contraseña desde la configuración de Supabase
+        const correctPassword = await getPasswordFromConfig();
+        
+        if (!correctPassword) {
+            console.error('⚠️ APP_PASSWORD no configurada en Supabase');
+            authError.textContent = 'Error de configuración. Contacte al administrador.';
+            authError.style.display = 'block';
+            return;
+        }
+        
+        if (enteredPassword === correctPassword) {
+            // Contraseña correcta
+            state.authenticated = true;
+            sessionStorage.setItem('app_authenticated', 'true');
+            authModal.classList.remove('active');
+            authError.style.display = 'none';
+            appPassword.value = '';
+            initializeApp();
+        } else {
+            // Contraseña incorrecta
+            authError.textContent = 'Contraseña incorrecta';
+            authError.style.display = 'block';
+            appPassword.value = '';
+            appPassword.focus();
+        }
+    } catch (error) {
+        console.error('Error al validar contraseña:', error);
+        authError.textContent = 'Error al verificar la contraseña. Inténtelo de nuevo.';
+        authError.style.display = 'block';
+    }
+}
+
+// Obtener contraseña desde la configuración de Supabase
+async function getPasswordFromConfig() {
+    try {
+        // Primero intentar desde la configuración de Supabase
+        if (state.config && state.config.appPassword) {
+            return state.config.appPassword;
+        }
+        
+        // Si no está en el estado, cargar desde Supabase
+        const response = await fetch(getSupabaseUrl('config?select=app_password&id=eq.1'), {
+            headers: getSupabaseHeaders()
+        });
+        
+        if (response.ok) {
+            const data = await response.json();
+            if (data && data.length > 0 && data[0].app_password) {
+                return data[0].app_password;
+            }
+        }
+        
+        // Fallback a variable de entorno si no está en Supabase
+        return window.ENV?.APP_PASSWORD;
+        
+    } catch (error) {
+        console.error('Error obteniendo contraseña de configuración:', error);
+        // Fallback a variable de entorno en caso de error
+        return window.ENV?.APP_PASSWORD;
+    }
+}
+
+// Inicializar aplicación después de autenticación
+async function initializeApp() {
+    // Mostrar la vista principal
+    document.getElementById('mainView').classList.add('active');
+    
+    // Inicializar Stripe
+    if (window.ENV?.STRIPE_PUBLIC_KEY) {
+        state.stripe = Stripe(window.ENV.STRIPE_PUBLIC_KEY);
+        console.log('✅ Stripe inicializado');
+    } else {
+        console.error('⚠️ STRIPE_PUBLIC_KEY no configurada');
+    }
+    
+    // Cargar configuración desde localStorage o Supabase
+    await cargarConfiguracion();
+    
+    // Renderizar interfaz
+    renderizarTickets();
+    actualizarCarrito();
+    
+    // Verificar si hay pedido activo
+    verificarPedidoActivo();
+    
+    // Configurar sincronización automática cada 30 segundos
+    setInterval(sincronizarConSupabase, 30000);
+}
+
+// Modificar la función cargarConfiguracion para incluir app_password
+// Esta función debe ser actualizada en app.js para incluir app_password en la consulta
+/*
+Modificar esta línea en cargarConfiguracion():
+const response = await fetch(getSupabaseUrl('config?select=*'), {
+
+Para asegurarse de que incluya app_password:
+const response = await fetch(getSupabaseUrl('config?select=*'), {
+*/

--- a/auth_supabase_integration_fixed.js
+++ b/auth_supabase_integration_fixed.js
@@ -1,0 +1,151 @@
+// Modificaciones necesarias para app.js - VERSIÓN CORREGIDA PARA UUID
+// Estas funciones deben reemplazar las funciones de autenticación existentes
+
+// === FUNCIONES DE AUTENTICACIÓN CON SUPABASE ===
+
+// Configurar autenticación
+function setupAuthentication() {
+    const authModal = document.getElementById('authModal');
+    const authSubmit = document.getElementById('authSubmit');
+    const appPassword = document.getElementById('appPassword');
+    const authError = document.getElementById('authError');
+    
+    // Verificar si ya está autenticado (sesión guardada)
+    const sessionAuth = sessionStorage.getItem('app_authenticated');
+    if (sessionAuth === 'true') {
+        state.authenticated = true;
+        authModal.classList.remove('active');
+        initializeApp();
+        return;
+    }
+    
+    // Manejar submit con Enter
+    appPassword.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            validatePassword();
+        }
+    });
+    
+    // Manejar click en botón
+    authSubmit.addEventListener('click', validatePassword);
+}
+
+// Validar contraseña usando configuración de Supabase
+async function validatePassword() {
+    const appPassword = document.getElementById('appPassword');
+    const authError = document.getElementById('authError');
+    const authModal = document.getElementById('authModal');
+    
+    const enteredPassword = appPassword.value;
+    
+    try {
+        // Obtener la contraseña desde la configuración de Supabase
+        const correctPassword = await getPasswordFromConfig();
+        
+        if (!correctPassword) {
+            console.error('⚠️ APP_PASSWORD no configurada en Supabase');
+            authError.textContent = 'Error de configuración. Contacte al administrador.';
+            authError.style.display = 'block';
+            return;
+        }
+        
+        if (enteredPassword === correctPassword) {
+            // Contraseña correcta
+            state.authenticated = true;
+            sessionStorage.setItem('app_authenticated', 'true');
+            authModal.classList.remove('active');
+            authError.style.display = 'none';
+            appPassword.value = '';
+            initializeApp();
+        } else {
+            // Contraseña incorrecta
+            authError.textContent = 'Contraseña incorrecta';
+            authError.style.display = 'block';
+            appPassword.value = '';
+            appPassword.focus();
+        }
+    } catch (error) {
+        console.error('Error al validar contraseña:', error);
+        authError.textContent = 'Error al verificar la contraseña. Inténtelo de nuevo.';
+        authError.style.display = 'block';
+    }
+}
+
+// Obtener contraseña desde la configuración de Supabase
+async function getPasswordFromConfig() {
+    try {
+        // Primero intentar desde la configuración de Supabase
+        if (state.config && state.config.appPassword) {
+            return state.config.appPassword;
+        }
+        
+        // Si no está en el estado, cargar desde Supabase
+        // Nota: No filtramos por id específico porque es UUID
+        const response = await fetch(getSupabaseUrl('config?select=app_password&limit=1'), {
+            headers: getSupabaseHeaders()
+        });
+        
+        if (response.ok) {
+            const data = await response.json();
+            if (data && data.length > 0 && data[0].app_password) {
+                return data[0].app_password;
+            }
+        }
+        
+        // Fallback a variable de entorno si no está en Supabase
+        return window.ENV?.APP_PASSWORD;
+        
+    } catch (error) {
+        console.error('Error obteniendo contraseña de configuración:', error);
+        // Fallback a variable de entorno en caso de error
+        return window.ENV?.APP_PASSWORD;
+    }
+}
+
+// Inicializar aplicación después de autenticación
+async function initializeApp() {
+    // Mostrar la vista principal
+    document.getElementById('mainView').classList.add('active');
+    
+    // Inicializar Stripe
+    if (window.ENV?.STRIPE_PUBLIC_KEY) {
+        state.stripe = Stripe(window.ENV.STRIPE_PUBLIC_KEY);
+        console.log('✅ Stripe inicializado');
+    } else {
+        console.error('⚠️ STRIPE_PUBLIC_KEY no configurada');
+    }
+    
+    // Cargar configuración desde localStorage o Supabase
+    await cargarConfiguracion();
+    
+    // Renderizar interfaz
+    renderizarTickets();
+    actualizarCarrito();
+    
+    // Verificar si hay pedido activo
+    verificarPedidoActivo();
+    
+    // Configurar sincronización automática cada 30 segundos
+    setInterval(sincronizarConSupabase, 30000);
+}
+
+// NOTA IMPORTANTE: 
+// También necesitas modificar la función cargarConfiguracion() en app.js
+// para que incluya app_password en la consulta SELECT y lo almacene en state.config
+//
+// Busca esta línea en cargarConfiguracion():
+// const response = await fetch(getSupabaseUrl('config?select=*'), {
+//
+// Y asegúrate de que cuando se carga la configuración desde Supabase,
+// se incluya app_password en el state.config:
+// 
+// if (configData && configData.length > 0) {
+//     const config = configData[0];
+//     state.config = {
+//         ...state.config,
+//         appTitle: config.app_title || state.config.appTitle,
+//         adminCode: config.admin_code || state.config.adminCode,
+//         securityCode: config.security_code || state.config.securityCode,
+//         appPassword: config.app_password || null  // <-- AGREGAR ESTA LÍNEA
+//     };
+// }

--- a/supabase_auth_setup.sql
+++ b/supabase_auth_setup.sql
@@ -1,0 +1,19 @@
+-- Script para agregar autenticación a la tabla de configuración de Supabase
+-- Ejecutar este script en el SQL Editor de Supabase
+
+-- 1. Agregar el campo app_password a la tabla config
+-- (Asegúrate de que la tabla config existe primero)
+ALTER TABLE config ADD COLUMN IF NOT EXISTS app_password TEXT;
+
+-- 2. Insertar/actualizar la configuración de autenticación
+-- Cambia 'tu-contraseña-segura' por la contraseña que desees
+INSERT INTO config (id, app_password) 
+VALUES (1, 'tu-contraseña-segura')
+ON CONFLICT (id) 
+DO UPDATE SET app_password = EXCLUDED.app_password;
+
+-- 3. Verificar que se insertó correctamente
+SELECT id, app_password FROM config WHERE id = 1;
+
+-- Nota: Si quieres cambiar la contraseña más tarde, simplemente ejecuta:
+-- UPDATE config SET app_password = 'nueva-contraseña' WHERE id = 1;

--- a/supabase_auth_setup_fixed.sql
+++ b/supabase_auth_setup_fixed.sql
@@ -1,0 +1,27 @@
+-- Script corregido para agregar autenticación a la tabla de configuración de Supabase
+-- Ejecutar este script en el SQL Editor de Supabase
+
+-- 1. Agregar el campo app_password a la tabla config
+ALTER TABLE config ADD COLUMN IF NOT EXISTS app_password TEXT;
+
+-- 2. Primero verificar si existe algún registro en la tabla config
+SELECT * FROM config LIMIT 5;
+
+-- 3. Si hay registros existentes, actualizar el primero:
+-- (Ejecuta este comando después de ver los resultados del SELECT anterior)
+-- UPDATE config SET app_password = 'tu-contraseña-segura' WHERE id = (SELECT id FROM config LIMIT 1);
+
+-- 4. Si NO hay registros, insertar uno nuevo:
+-- INSERT INTO config (id, app_password) VALUES (gen_random_uuid(), 'tu-contraseña-segura');
+
+-- 5. Verificar el resultado
+SELECT id, app_password FROM config;
+
+-- INSTRUCCIONES:
+-- 1. Ejecuta primero las líneas 1-8 (ALTER TABLE y SELECT)
+-- 2. Si hay registros, ejecuta la línea UPDATE (descomentándola)
+-- 3. Si NO hay registros, ejecuta la línea INSERT (descomentándola)
+-- 4. Ejecuta la verificación final
+
+-- Para cambiar la contraseña más tarde:
+-- UPDATE config SET app_password = 'nueva-contraseña' WHERE id = (SELECT id FROM config LIMIT 1);


### PR DESCRIPTION
## Summary
Fix the SQL script to properly handle UUID primary keys in the config table instead of assuming integer IDs.

## Problem Fixed
The previous SQL script failed with:
```
ERROR: column "id" is of type uuid but expression is of type integer
```

## Solution
1. **supabase_auth_setup_fixed.sql**: Corrected SQL script that:
   - Uses `gen_random_uuid()` for new records
   - Uses `LIMIT 1` instead of `id=1` for existing records
   - Provides step-by-step instructions

2. **auth_supabase_integration_fixed.js**: Updated JavaScript functions that:
   - Query config with `limit=1` instead of `id=eq.1`
   - Handle UUID primary keys correctly
   - Include proper fallback to environment variables

3. **SETUP_AUTH_SUPABASE_FIXED.md**: Complete corrected setup instructions

## Usage
Execute this SQL step by step in Supabase:

```sql
-- 1. Add the field
ALTER TABLE config ADD COLUMN IF NOT EXISTS app_password TEXT;

-- 2. Check existing records
SELECT * FROM config LIMIT 5;

-- 3. If records exist, update the first one:
UPDATE config SET app_password = 'your-secure-password' 
WHERE id = (SELECT id FROM config LIMIT 1);

-- 4. Verify
SELECT id, app_password FROM config;
```

🤖 Generated with [Claude Code](https://claude.ai/code)